### PR TITLE
Update README.SUSE

### DIFF
--- a/doc/README.SUSE
+++ b/doc/README.SUSE
@@ -36,7 +36,7 @@ resulting in a binary kernel.
 The add-on patches and configuration files are maintained in
 a GIT repository at
 
-    http://gitorious.org/opensuse/kernel-source
+    https://github.com/openSUSE/kernel-source
     
 A script (scripts/tar-up.sh) packs up the files in the repository in a
 form suitable for rpmbuild. When building the RPM packages, the


### PR DESCRIPTION
Changed the link for the openSUSE kernel sources from a gitorious one to the current github one.